### PR TITLE
Update action.yml to node20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,6 @@ outputs:
   build-url:
     description: Build page on Codemagic
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 


### PR DESCRIPTION
Update version to fix deprecation warning. 

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

You will also probably have to bump the action to v2