### PR TITLE
Feature: use Node 20

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the following configuration to `.github/workflows/main.yml` to trigger Codem
         runs-on: ubuntu-latest
         steps:
           - name: Trigger Codemagic build
-            uses: codemagic-ci-cd/trigger-codemagic-workflow-action@v1.0.0
+            uses: codemagic-ci-cd/trigger-codemagic-workflow-action@v2.0.0
             with:
               app-id: <MY-APPLICATION-ID>
               workflow-id: <MY-WORKFLOW-ID>

--- a/action.yml
+++ b/action.yml
@@ -44,6 +44,6 @@ outputs:
   build-url:
     description: Build page on Codemagic
 runs:
-  using: node16
+  using: node20
   main: dist/index.js
 


### PR DESCRIPTION
Node 16 is now deprecated. Run the action with Node 20 to hide the warning.

Initially reported here: https://github.com/codemagic-ci-cd/trigger-codemagic-workflow-action/pull/6

https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions

# Post-merge

Tag merge commit v2.0.0